### PR TITLE
CORE-4886: stopping to expose "effective_tenant_id" and "effective_us…

### DIFF
--- a/Run/State/StateAPI.cs
+++ b/Run/State/StateAPI.cs
@@ -202,19 +202,5 @@ namespace ManyWho.Flow.SDK.Run.State
             get;
             set;
         }
-        
-        [DataMember]
-        public Guid? effectiveTenantId
-        {
-            get;
-            set;
-        }
-        
-        [DataMember]
-        public Guid? effectiveUserId
-        {
-            get;
-            set;
-        }
     }
 }


### PR DESCRIPTION
…er_id" fields in the APIs