### PR TITLE
CORE-5241: Subflow map element logic in Debug Step-through mode

### DIFF
--- a/ManyWhoConstants.cs
+++ b/ManyWhoConstants.cs
@@ -912,6 +912,7 @@ namespace ManyWho.Flow.SDK
 
         // Guids for the reserved outcomes for faults and debug
         public static readonly Guid DEBUG_GUID = Guid.Parse("EE6C8827-11E2-486D-B5FA-4D1A0CBB77A3");
+        public static readonly Guid DEBUG2_GUID = Guid.Parse("119377D8-EE1D-B792-4A05-B2E5F344885C"); //Subflow map element is executed twice (when going into a subflow and when returning) so we need another debug outcome to know which execution it is
         public static readonly Guid FAULT_GUID = Guid.Parse("318B0F3A-A570-4C5D-835C-21C1EEB17787");
 
         // Outcomes with a fault

--- a/ManyWhoConstants.cs
+++ b/ManyWhoConstants.cs
@@ -912,7 +912,6 @@ namespace ManyWho.Flow.SDK
 
         // Guids for the reserved outcomes for faults and debug
         public static readonly Guid DEBUG_GUID = Guid.Parse("EE6C8827-11E2-486D-B5FA-4D1A0CBB77A3");
-        public static readonly Guid DEBUG2_GUID = Guid.Parse("119377D8-EE1D-B792-4A05-B2E5F344885C"); //Subflow map element is executed twice (when going into a subflow and when returning) so we need another debug outcome to know which execution it is
         public static readonly Guid FAULT_GUID = Guid.Parse("318B0F3A-A570-4C5D-835C-21C1EEB17787");
 
         // Outcomes with a fault

--- a/Run/EngineFrameAPI.cs
+++ b/Run/EngineFrameAPI.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace ManyWho.Flow.SDK.Run
+{
+    [DataContract(Namespace = "http://www.manywho.com/api")]
+    public class EngineFrameAPI
+    {
+        /// <summary>
+        /// The id of the flow associated with this stack frame
+        /// </summary>
+        [DataMember]
+        public Guid FlowId
+        {
+            get;
+            set;
+        }
+        
+        /// <summary>
+        /// If this frame is the current frame, this property contains the id of the current map element.
+        /// If this frame refers to one of the parent frames, this property contains the id of a Subflow map element that was the entry point to the next frame. 
+        /// </summary>
+        [DataMember]
+        public Guid? MapElementId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// If this frame is the current frame, this property contains the developer name of the current map element.
+        /// If this frame refers to one of the parent frames, this property contains the id of a Subflow map element that was the entry point to the next frame. 
+        /// </summary>
+        [DataMember]
+        public string MapElementDeveloperName
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/Run/EngineInvokeResponseAPI.cs
+++ b/Run/EngineInvokeResponseAPI.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using ManyWho.Flow.SDK.Run.Elements.Map;
 using ManyWho.Flow.SDK.Run.Elements.UI;
@@ -188,6 +187,16 @@ namespace ManyWho.Flow.SDK.Run
             get;
             set;
         }
+
+        /// <summary>
+        /// This property is populated is only in debug mode. It contains the list of current stack frames.
+        /// </summary>
+        [DataMember]
+        public List<EngineFrameAPI> frames
+        {
+            get; 
+            set;
+        }    
 
         /// <summary>
         /// The values mimic standard REST codes, but as a String. A "200" indicates the user is authenticated to execute the flow. A "401" indicates the user needs to login based on the authorization context information provided in the response.


### PR DESCRIPTION
Need a second DEBUG_GUID magic number to distinguish between
1) Subflow element being executed when going into a subflow
OR 
2) Subflow element being executed when returning to the parent