### PR TITLE
FLOW-1342 - When validating url query parameters a hard-coded message…

### DIFF
--- a/Utils/Validation.cs
+++ b/Utils/Validation.cs
@@ -74,7 +74,7 @@ namespace ManyWho.Flow.SDK.Utils
         {
             if (!string.IsNullOrWhiteSpace(value))
             {
-                if (!string.IsNullOrWhiteSpace(message))
+                if (string.IsNullOrWhiteSpace(message))
                 {
                     message = name + " must be null or whitespace";
                 }


### PR DESCRIPTION
… should only be returned if the message provided is either null or white space, this caused errors generated from IDP's leveraging oauth2 to not be included in the responses from the engines oauth2 endpoint